### PR TITLE
Add in-memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ const config = await getConfig("/mydomain/myapp/");
 // TODO: Do something with config
 ```
 
+Or perhaps you're using Lambda and want to only fetch config once per invocation:
+
+```js
+import { withCache } from "dotssm";
+
+export const myHandler = async (event, context) => {
+  const getConfig = withCache();
+  await serviceA(getConfig);
+  await serviceB(getConfig);
+  // The first call to getConfig will fetch from SSM
+  // Everything thereafter will use the cached result
+};
+```
+
 The client making the above request requires the following IAM policy:
 
 ```json

--- a/lib/cache.spec.ts
+++ b/lib/cache.spec.ts
@@ -1,0 +1,58 @@
+import { cache } from "./cache";
+import { GetConfigFunc, Config } from "./types";
+
+describe("Given there is a config cache", () => {
+  const stubbedResult = { "/foo": "bar" };
+  const anyNamespace = "/any/namespace";
+
+  let getConfigStub: jest.Mock;
+  let getConfig: GetConfigFunc;
+  let result: Config;
+  beforeEach(() => {
+    getConfigStub = jest.fn().mockResolvedValue(stubbedResult);
+    getConfig = cache(getConfigStub);
+  });
+
+  describe("When the config is fetched", () => {
+    beforeEach(async () => (result = await getConfig(anyNamespace)));
+
+    it("Then returns the config result", async () => {
+      expect(result).toEqual(stubbedResult);
+    });
+  });
+
+  describe("And the config has already been fetched", () => {
+    beforeEach(() => getConfig(anyNamespace));
+
+    describe("When the config is fetched a second time", () => {
+      beforeEach(async () => (result = await getConfig(anyNamespace)));
+
+      it("Then the config result is returned", async () => {
+        expect(result).toEqual(stubbedResult);
+      });
+
+      it("Then the config was not refetched", () => {
+        expect(getConfigStub).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("When the config is fetched by two consumers simultaneously", () => {
+    let results: Config[];
+    beforeEach(async () => {
+      results = await Promise.all([
+        getConfig(anyNamespace),
+        getConfig(anyNamespace)
+      ]);
+    });
+
+    it("Then the config result is returned correctly twice", async () => {
+      expect(results[0]).toEqual(stubbedResult);
+      expect(results[1]).toEqual(stubbedResult);
+    });
+
+    it("Then the config is only fetched once", async () => {
+      expect(getConfigStub).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,13 @@
+import { GetConfigFunc, Config } from "./types";
+
+export const cache = (getConfig: GetConfigFunc): GetConfigFunc => {
+  let promise: Promise<Config>;
+
+  return (namespace: string): Promise<Config> => {
+    if (promise) {
+      return promise;
+    }
+    promise = getConfig(namespace);
+    return promise;
+  };
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import { GetConfigFunc } from "./types";
 import { fallback } from "./fallback";
 import { local } from "./local";
 import { ssm } from "./ssm";
+import { cache } from "./cache";
 
 // Re-export types so that they can be used in consuming packages
 export { GetConfigFunc, Config, NO_CONFIG } from "./types";
@@ -25,6 +26,16 @@ export const getConfig: GetConfigFunc = fallback(local(), ssm());
  */
 export const withAWSClient = (client: AWS.SSM): GetConfigFunc =>
   fallback(local(), ssm(client));
+
+/**
+ * Wraps a config getter function with an in-memory cache that prevents refetching
+ * values for the lifetime of the config getter. Said another way, ensures that the given
+ * config getter function is only ever called once.
+ *
+ * @param fn The config getter function to wrap with the cache, uses the `getConfig` function by default
+ * @return a function that can be called with a namespace value to retrieve config.
+ */
+export const withCache = (fn = getConfig): GetConfigFunc => cache(fn);
 
 // TODO: We'll probably want schema validation at some point
 // but do we want to bundle it in this library? Or somewhere else?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dotssm",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotssm",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "dotenv for SSM",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes #17 by allowing multiple calls to get config easily without refetching from SSM.